### PR TITLE
Add fast_hash for column_encoder.MinHashing()

### DIFF
--- a/column_encoder.py
+++ b/column_encoder.py
@@ -26,9 +26,9 @@ from fast_hash import ngram_min_hash
 from utils import LRUDict
 
 CE_HOME = os.environ.get('CE_HOME')
-# sys.path.append(os.path.abspath(os.path.join(
-#     CE_HOME, 'python', 'categorical_encoding')))
-# from get_data import get_data_path
+sys.path.append(os.path.abspath(os.path.join(
+    CE_HOME, 'python', 'categorical_encoding')))
+from get_data import get_data_path
 
 
 class OneHotEncoderRemoveOne(OneHotEncoder):

--- a/fast_hash.py
+++ b/fast_hash.py
@@ -1,0 +1,90 @@
+"""
+n-gram hashing by simple dot products
+
+The principle is as follows:
+  1. A string is viewed as a succession of numbers (the ASCII or UTF8
+     representation of its elements.
+  2. Each n-gram is then an n-dimensional vector of integers "g". A simple
+     hash function is then computed by taking the dot product with a
+     given random vector "atom", modulo max-int (integers larger than
+     max-int overflow). The corresponding operation defines a random
+     order in the interval [-maxint, maxint]
+  3. Computing this dot product over a sliding window (to compute it for
+     every n-gram is a convolution
+  4. We can then take the min (or the max) of the resulting sliding
+  window
+
+"""
+import functools
+import numpy as np
+
+@functools.lru_cache(maxsize=1024)
+def gen_atom(atom_len, dtype_size=32, seed=0):
+    """ Generate a random integer atom
+
+    Parameters
+    ----------
+    atom_len: int
+        The length of the atom
+    dtype_size: int, default=32
+        The size of the integer used
+    seed: int, default=0
+        The seed of the random_number generator
+
+    Returns
+    -------
+    atom: 1D array of integers
+        An array of random integers of length atom_len and dtype int32 if
+        dtype_size=32
+    """
+    rng = np.random.RandomState(seed)
+    maxint = 2 ** (dtype_size - 1) - 1
+    atom = rng.randint(-maxint, maxint, size=atom_len,
+                       dtype=np.dtype('int%i' % dtype_size))
+    return atom
+
+# @profile
+def ngram_min_hash(string, ngram_range=(2, 4), seed=0, return_minmax=False):
+    """ Compute the min hash of the ngrams of the string
+
+    Parameters
+    ----------
+    string: str
+        String to min-hash
+    ngram_range: list
+        List of ngram sizes to compute hashes for
+    seed: integer
+        Integer used to seed the hashing function
+    Return
+    -------
+    min_hash: integer
+    """
+    # Create a numerical 1D array from the string
+    array = np.frombuffer(string.encode(), dtype='int8', count=len(string))
+    dtype_size = 32
+
+    max_hash = -np.inf
+    min_hash = np.inf
+    for atom_len in range(ngram_range[0], ngram_range[1]):
+        atom = gen_atom(atom_len, dtype_size=dtype_size, seed=seed)
+        # np.correlate is faster than np.convolve
+        hashes = np.correlate(array, atom)
+        new_min = hashes.min()
+        min_hash = min(min_hash, new_min)
+        if return_minmax:
+            max_hash = max(max_hash, hashes.max())
+
+    # We should check that longer windows do not have different
+    # statistics from shorter ones
+    if return_minmax:
+        return min_hash, max_hash
+    return min_hash
+
+
+if __name__ == '__main__':
+    # Download demo text
+    from sklearn import datasets
+    data = datasets.fetch_20newsgroups()
+    a = data.data[0]
+
+    h = ngram_min_hash(a)

--- a/fast_hash.py
+++ b/fast_hash.py
@@ -18,13 +18,13 @@ The principle is as follows:
 import functools
 import numpy as np
 
-# Precompute to avoid the cost
+# Precompute to avoid the cost and
 # cast to int32 to speedup the min 
 MININT32 = np.int32(-2 ** (32 - 1))
 MAXINT32 = np.int32(2 ** (32 - 1) - 1)
 
 @functools.lru_cache(maxsize=1024)
-def gen_atom(atom_len, dtype_size=32, seed=0):
+def gen_atom(atom_len, seed=0):
     """ Generate a random integer atom
 
     Parameters
@@ -37,8 +37,8 @@ def gen_atom(atom_len, dtype_size=32, seed=0):
     Returns
     -------
     atom: 1D array of integers
-        An array of random integers of length atom_len and dtype int32 if
-        dtype_size=32
+        An array of random integers of length atom_len and dtype int32
+        (assuming dtype_size=32)
     """
     rng = np.random.RandomState(seed)
     atom = rng.randint(-MAXINT32, MAXINT32, size=atom_len,
@@ -53,8 +53,9 @@ def ngram_min_hash(string, ngram_range=(2, 4), seed=0, return_minmax=False):
     ----------
     string: str
         String to min-hash
-    ngram_range: list
-        List of ngram sizes to compute hashes for
+    ngram_range: tuple (min_n, max_n)
+        The lower and upper boundary of the range of n-values 
+        for different n-grams to be extracted.
     seed: integer
         Integer used to seed the hashing function
     Return

--- a/tests/test_column_encoder.py
+++ b/tests/test_column_encoder.py
@@ -3,50 +3,55 @@ import time
 import pandas as pd
 
 from sklearn.datasets import fetch_20newsgroups
-from column_encoder import MinHashEncoder
+from string_categorical_encoders.column_encoder import MinHashEncoder
 
 
 def test_MinHashEncoder(n_sample=70, minmax_hash=False):
     X_txt = fetch_20newsgroups(subset='train')['data']
     X = X_txt[:n_sample]
 
-    for hashing in ['fast_hash', 'murmur_hash']:
+    for minmax_hash in [True, False]:
+        for hashing in ['fast', 'murmur']:
 
-        # Test output shape
-        encoder = MinHashEncoder(n_components=50, hashing=hashing)
-        encoder.fit(X)
-        y = encoder.transform(X)
-        assert y.shape == (n_sample, 50), str(y.shape)
-        assert len(set(y[0])) == 50
+            if minmax_hash and hashing == 'murmur':
+                pass # not implemented
 
-        # Test same seed return the same output
-        encoder = MinHashEncoder(50, hashing=hashing)
-        encoder.fit(X)
-        y2 = encoder.transform(X)
-        np.testing.assert_array_equal(y, y2)
+            # Test output shape
+            encoder = MinHashEncoder(n_components=50, hashing=hashing)
+            encoder.fit(X)
+            y = encoder.transform(X)
+            assert y.shape == (n_sample, 50), str(y.shape)
+            assert len(set(y[0])) == 50
 
-        # Test min property
-        if not minmax_hash:
-            X_substring = [x[:x.find(' ')] for x in X]
+            # Test same seed return the same output
             encoder = MinHashEncoder(50, hashing=hashing)
-            encoder.fit(X_substring)
-            y_substring = encoder.transform(X_substring)
-            np.testing.assert_array_less(y - y_substring, 0.0001)
+            encoder.fit(X)
+            y2 = encoder.transform(X)
+            np.testing.assert_array_equal(y, y2)
+
+            # Test min property
+            if not minmax_hash:
+                X_substring = [x[:x.find(' ')] for x in X]
+                encoder = MinHashEncoder(50, hashing=hashing)
+                encoder.fit(X_substring)
+                y_substring = encoder.transform(X_substring)
+                np.testing.assert_array_less(y - y_substring, 0.0001)
 
 
-def profile_encoder(Encoder, hashing='fast_hash'):
+def profile_encoder(Encoder, hashing='fast', minmax_hash=False):
 
     from dirty_cat import datasets
     employee_salaries = datasets.fetch_employee_salaries()
     data = pd.read_csv(employee_salaries['path'])
-    X = data['Employee Position Title']
-
+    X = data['Employee Position Title'].tolist()
+    X = X * 10
     t0 = time.time()
-    encoder = Encoder(n_components=50, hashing=hashing)
+    encoder = Encoder(n_components=50, hashing=hashing, minmax_hash=minmax_hash)
     encoder.fit(X)
     y = encoder.transform(X)
     assert y.shape == (len(X), 50)
-    return time.time() - t0
+    eta = time.time() - t0
+    return eta
 
 
 if __name__ == '__main__':
@@ -54,9 +59,14 @@ if __name__ == '__main__':
     test_MinHashEncoder()
     print('test passed')
 
-    print('time profile_encoder(MinHashEncoder, hashing=fast_hash)')
-    print("{:.4} seconds".format(profile_encoder(MinHashEncoder, hashing='fast_hash')))
-    print('time profile_encoder(MinHashEncoder, hashing=murmur_hash)')
-    print("{:.4} seconds".format(profile_encoder(MinHashEncoder, hashing='murmur_hash')))
+    for _ in range(3):
+        print('time profile_encoder(MinHashEncoder, hashing=fast)')
+        print("{:.4} seconds".format(profile_encoder(MinHashEncoder, hashing='fast')))
+    for _ in range(3):
+        print('time profile_encoder(MinHashEncoder, hashing=fast) with minmax')
+        print("{:.4} seconds".format(profile_encoder(MinHashEncoder,
+                         hashing='fast', minmax_hash=True)))
+    print('time profile_encoder(MinHashEncoder, hashing=murmur)')
+    print("{:.4} seconds".format(profile_encoder(MinHashEncoder, hashing='murmur')))
 
     print('Done')

--- a/tests/test_column_encoder.py
+++ b/tests/test_column_encoder.py
@@ -1,0 +1,62 @@
+import numpy as np
+import time
+import pandas as pd
+
+from sklearn.datasets import fetch_20newsgroups
+from column_encoder import MinHashEncoder
+
+
+def test_MinHashEncoder(n_sample=70, minmax_hash=False):
+    X_txt = fetch_20newsgroups(subset='train')['data']
+    X = X_txt[:n_sample]
+
+    for hashing in ['fast_hash', 'murmur_hash']:
+
+        # Test output shape
+        encoder = MinHashEncoder(n_components=50, hashing=hashing)
+        encoder.fit(X)
+        y = encoder.transform(X)
+        assert y.shape == (n_sample, 50), str(y.shape)
+        assert len(set(y[0])) == 50
+
+        # Test same seed return the same output
+        encoder = MinHashEncoder(50, hashing=hashing)
+        encoder.fit(X)
+        y2 = encoder.transform(X)
+        np.testing.assert_array_equal(y, y2)
+
+        # Test min property
+        if not minmax_hash:
+            X_substring = [x[:x.find(' ')] for x in X]
+            encoder = MinHashEncoder(50, hashing=hashing)
+            encoder.fit(X_substring)
+            y_substring = encoder.transform(X_substring)
+            np.testing.assert_array_less(y - y_substring, 0.0001)
+
+
+def profile_encoder(Encoder, hashing='fast_hash'):
+
+    from dirty_cat import datasets
+    employee_salaries = datasets.fetch_employee_salaries()
+    data = pd.read_csv(employee_salaries['path'])
+    X = data['Employee Position Title']
+
+    t0 = time.time()
+    encoder = Encoder(n_components=50, hashing=hashing)
+    encoder.fit(X)
+    y = encoder.transform(X)
+    assert y.shape == (len(X), 50)
+    return time.time() - t0
+
+
+if __name__ == '__main__':
+    print('start test')
+    test_MinHashEncoder()
+    print('test passed')
+
+    print('time profile_encoder(MinHashEncoder, hashing=fast_hash)')
+    print("{:.4} seconds".format(profile_encoder(MinHashEncoder, hashing='fast_hash')))
+    print('time profile_encoder(MinHashEncoder, hashing=murmur_hash)')
+    print("{:.4} seconds".format(profile_encoder(MinHashEncoder, hashing='murmur_hash')))
+
+    print('Done')

--- a/tests/test_fast_hash.py
+++ b/tests/test_fast_hash.py
@@ -1,0 +1,22 @@
+from fast_hash import ngram_min_hash
+
+
+def test_fast_hash():
+
+    from sklearn import datasets
+    data = datasets.fetch_20newsgroups()
+    a = data.data[0]
+
+    min_hash = ngram_min_hash(a, seed=0)
+    min_hash2 = ngram_min_hash(a, seed=0)
+    assert min_hash == min_hash2
+
+    list_min_hash = [ngram_min_hash(a, seed=seed) for seed in range(50)]
+    assert len(set(list_min_hash)) > 45, 'Too many hash collisions'
+
+    min_hash4 = ngram_min_hash(a, seed=0, return_minmax=True)
+    assert len(min_hash4) == 2
+
+
+if __name__ == '__main__':
+    test_fast_hash()

--- a/tests/test_fast_hash.py
+++ b/tests/test_fast_hash.py
@@ -1,4 +1,4 @@
-from fast_hash import ngram_min_hash
+from string_categorical_encoders.fast_hash import ngram_min_hash
 
 
 def test_fast_hash():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+from string_categorical_encoders.utils import LRUDict
+
+
+def test_lrudict():
+    dict_ = LRUDict(10)
+
+    for x in range(15):
+        dict_[x] = 'filled'+str(x)
+
+    for x in range(5, 15):
+        assert x in dict_
+        assert dict_[x] == 'filled'+str(x)
+
+    for x in range(5):
+        assert (x not in dict_)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,26 @@
+import collections
+
+
+class LRUDict:
+    """ dict with limited capacity
+
+    Using LRU eviction, this avoid to memorizz a full dataset"""
+    def __init__(self, capacity):
+        self.capacity = capacity
+        self.cache = collections.OrderedDict()
+
+    def __getitem__(self, key):
+        try:
+            value = self.cache.pop(key)
+            self.cache[key] = value
+            return value
+        except KeyError:
+            return -1
+
+    def __setitem__(self, key, value):
+        try:
+            self.cache.pop(key)
+        except KeyError:
+            if len(self.cache) >= self.capacity:
+                self.cache.popitem(last=False)
+        self.cache[key] = value

--- a/utils.py
+++ b/utils.py
@@ -24,3 +24,6 @@ class LRUDict:
             if len(self.cache) >= self.capacity:
                 self.cache.popitem(last=False)
         self.cache[key] = value
+
+    def __contains__(self, key):
+        return key in self.cache


### PR DESCRIPTION
MinHashEncoder() will use fast_hash.py for hashing ngrams by default. 

fast_hash speed up the computation by 2 (resp. 3 and 16) for string of length 20 (resp. 30, 300).

Fix #1, #5 